### PR TITLE
Fix camera left/right key bindings

### DIFF
--- a/R2FixCfg/def_button.h
+++ b/R2FixCfg/def_button.h
@@ -25,8 +25,8 @@
 	M_DefineAction( E_BAc_Strafe,			"Strafe / Dive",			"Button(5)" )
 	M_DefineAction( E_BAc_Look,				"Look Mode",				"Keyboard(Numpad0)" )
 	M_DefineAction( E_BAc_Camera_Reset,		"Reset Camera",				"Keyboard(End)" )
-	M_DefineAction( E_BAc_Camera_Left,		"Camera Left",				"Button(4)" )
-	M_DefineAction( E_BAc_Camera_Right,		"Camera Right",				"Button(3)" )
+	M_DefineAction( E_BAc_Camera_Left,		"Camera Left",				"Keyboard(W)" )
+	M_DefineAction( E_BAc_Camera_Right,		"Camera Right",				"Keyboard(Q)" )
 
 	M_DefineAction( E_BAc_Think,			"Think (F1)",				"Keyboard(F1)" )
 	M_DefineAction( E_BAc_HUD,				"HUD (J)",					"Button(6)" )


### PR DESCRIPTION
I had this bug while using an Xbox 360 controller connected through a wireless receiver where the camera stick worked but Camera Left/Camera Right bindings did not. The drivers for it are super old so I would not be surprised if it's causing some weird issues. After applying the same fix made to the camera stick from https://github.com/spitfirex86/Ray2Fix/commit/7acdfd19b52ae6f6d5038857c2938c6de7a7cce3 to the camera buttons they started working fine.

I don't fully understand why buttons 3 & 4 didn't work for me, but since the same fix was applied to the camera stick it should work fine for the buttons too.